### PR TITLE
Show ignored tokens from search API

### DIFF
--- a/LTU.SearchEngine.Frontend/src/Services/SearchApiFetch.ts
+++ b/LTU.SearchEngine.Frontend/src/Services/SearchApiFetch.ts
@@ -35,7 +35,6 @@ export const fetchFromApi = async (query: string, page: number = 0, language: st
     const url = `${BASE_URL}/search?${params}`;
     
     const response = await fetch(url);
-    
 
     if (!response.ok){
         let errorMessage = "An unexpected error occurred";

--- a/LTU.SearchEngine.Frontend/src/hooks/useSearch.ts
+++ b/LTU.SearchEngine.Frontend/src/hooks/useSearch.ts
@@ -49,8 +49,8 @@ export const useSearch = () => {
         try {
 
             setIsLoading(true);
-            const data = await fetchFromApi(query, page, language);
-            
+            const data: SearchResponse = await fetchFromApi(query, page, language);
+                
             setSearchData({...data});
 
             console.log("Valid query sent to API:", query); 

--- a/LTU.SearchEngine.Frontend/src/models/SearchInterface.ts
+++ b/LTU.SearchEngine.Frontend/src/models/SearchInterface.ts
@@ -16,4 +16,10 @@ export interface SearchResponse {
     totalResults: number;
     totalPages: number;
     message: string; 
+    ignoredTokens?: IgnoredToken[]
+}
+
+export interface IgnoredToken {
+    token: string;
+    language: string;
 }

--- a/LTU.SearchEngine.Frontend/src/views/SearchView.tsx
+++ b/LTU.SearchEngine.Frontend/src/views/SearchView.tsx
@@ -43,6 +43,7 @@ export const SearchView = () => {
 
       {searchData && (
         <>
+          <p>Ignored common terms: {searchData.ignoredTokens?.map((term) => term.token).join(', ') || 'None'}</p>
           <p>Found {searchData.totalResults} results</p>
           <small>{`Time taken: ${searchData.message}`}</small>
           <SearchResultList searchResults = {searchData.searchResults} />


### PR DESCRIPTION
Add support for reporting ignored common terms from the search API.
Introduce an IgnoredToken interface and make ignoredTokens optional on SearchResponse. 
Display the comma-separated ignored tokens in SearchView. 
Also add a concrete SearchResponse type annotation in useSearch and remove incidental trailing whitespace in SearchApiFetch.