### PR TITLE
16 update the frontend to use the backend pagination

### DIFF
--- a/LTU.SearchEngine.Frontend/src/Services/SearchApiFetch.ts
+++ b/LTU.SearchEngine.Frontend/src/Services/SearchApiFetch.ts
@@ -29,11 +29,10 @@ export const fetchFromApi = async (query: string, page: number = 0, language: st
     const params = new URLSearchParams({
         query: query,
         language: language,
-        // pageNumber: page.toString()
+        pageNumber: page.toString()
     });
  
     const url = `${BASE_URL}/search?${params}`;
-    
     const response = await fetch(url);
 
     if (!response.ok){

--- a/LTU.SearchEngine.Frontend/src/components/Pagination.tsx
+++ b/LTU.SearchEngine.Frontend/src/components/Pagination.tsx
@@ -1,16 +1,13 @@
+import type { PaginationMetaData } from "../models/SearchInterface";
+
 interface PaginationProps {
-  currentPage: number;
-  totalPages: number;
+  metaData: PaginationMetaData;
   onPageChange: (newPage: number) => void;
 }
 
-export const Pagination = ({
-  currentPage,
-  totalPages,
-  onPageChange,
-}: PaginationProps) => {
+export const Pagination = ({ metaData, onPageChange,}: PaginationProps) => {
 
-  if (totalPages <= 1) return null;
+  if (metaData.totalPages <= 1) return null;
 
   return (
     <div
@@ -22,19 +19,19 @@ export const Pagination = ({
       }}
     >
       <button
-        onClick={() => onPageChange(currentPage - 1)}
-        disabled={currentPage === 1}
+        onClick={() => onPageChange(metaData.currentPage - 1)}
+        disabled={!metaData.hasPrevious}
       >
         Previous
       </button>
 
       <span>
-        Page {currentPage} of {totalPages}
+        Page {metaData.currentPage} of {metaData.totalPages}
       </span>
 
       <button
-        onClick={() => onPageChange(currentPage + 1)}
-        disabled={currentPage === totalPages}
+        onClick={() => onPageChange(metaData.currentPage + 1)}
+        disabled={!metaData.hasNext}
       >
         Next
       </button>

--- a/LTU.SearchEngine.Frontend/src/models/SearchInterface.ts
+++ b/LTU.SearchEngine.Frontend/src/models/SearchInterface.ts
@@ -11,12 +11,18 @@ export interface SearchResultItem {
 
 export interface SearchResponse {
     searchResults: SearchResultItem[];
-    currentPage: number; // FRQ-4002
-    pageSize: number;
-    totalResults: number;
-    totalPages: number;
+    metaData: PaginationMetaData;
     message: string; 
     ignoredTokens?: IgnoredToken[]
+}
+
+export interface PaginationMetaData{
+    currentPage: number;
+    hasNext: boolean;
+    hasPrevious: boolean;
+    pageSize: number;
+    totalItemCount: number;
+    totalPages: number;
 }
 
 export interface IgnoredToken {

--- a/LTU.SearchEngine.Frontend/src/views/SearchView.tsx
+++ b/LTU.SearchEngine.Frontend/src/views/SearchView.tsx
@@ -29,7 +29,7 @@ export const SearchView = () => {
       {warning && <p className="warning-message">{warning}</p>}
 
       {/* Issue #12: Hantera noll resultat (FRQ-4003) */}
-      {searchData && searchData.totalResults === 0 && (
+      {searchData && searchData.metaData.totalItemCount === 0 && (
         <div className="no-results-container" style={{ marginTop: '20px', padding: '20px', backgroundColor: ' #3c4043;', borderRadius: '4px', border: '1px solid #ccc' }}>
           <h3>No results found</h3>
           <p>Your search for <strong>"{submittedQuery}"</strong> did not match any documents.</p>
@@ -44,13 +44,12 @@ export const SearchView = () => {
       {searchData && (
         <>
           <p>Ignored common terms: {searchData.ignoredTokens?.map((term) => term.token).join(', ') || 'None'}</p>
-          <p>Found {searchData.totalResults} results</p>
+          <p>Found {searchData.metaData.totalItemCount} results</p>
           <small>{`Time taken: ${searchData.message}`}</small>
           <SearchResultList searchResults = {searchData.searchResults} />
           {
             <Pagination
-              currentPage={searchData.currentPage}
-              totalPages={searchData.totalPages}
+              metaData={searchData.metaData}
               onPageChange={handlePageChange}
             />
           }


### PR DESCRIPTION
Switch Pagination to accept a PaginationMetaDat and use metaData.currentPage/totalPages/hasPrevious/hasNext for rendering and button states. 

Update SearchView to read totalItemCount from searchData.metaData and pass metaData into Pagination. 
Un-comment and send the pageNumber query parameter in SearchApiFetch so the backend receives the current page. 

These changes align the frontend with the API's metadata shape and fix pagination behavior.